### PR TITLE
Change to rg

### DIFF
--- a/lua/snacks/picker/source/explorer.lua
+++ b/lua/snacks/picker/source/explorer.lua
@@ -283,14 +283,15 @@ end
 ---@type snacks.picker.finder
 function M.search(opts, ctx)
   opts = Snacks.picker.util.shallow_copy(opts)
-  opts.cmd = "fd"
+  opts.cmd = "rg"
   opts.cwd = ctx.filter.cwd
   opts.notify = false
   opts.args = {
-    "--type",
-    "d", -- include directories
-    "--path-separator", -- same everywhere
-    "/",
+    "--files",
+    "--hidden", -- include directories
+    "--glob",
+    "!git",
+    opts.path or ".",
   }
   opts.dirs = { ctx.filter.cwd }
   ctx.picker.list:set_target()


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
This pull request includes a change to the `lua/snacks/picker/source/explorer.lua` file to modify the command used for searching files and directories. The most important change is the replacement of the `fd` command with the `rg` (ripgrep) command, along with adjustments to the arguments passed to the command.

Changes in search command and arguments:

* [`lua/snacks/picker/source/explorer.lua`](diffhunk://#diff-7f2030a9c8516121759042c05975490562932678e57f5775bc94cf26af657fdbL286-R294): Replaced the `fd` command with the `rg` command for searching files and directories. Updated the arguments to include `--files`, `--hidden`, and `--glob`, and removed the `--type` and `--path-separator` arguments.

<!-- Add screenshots of the changes if applicable. -->

