### PR TITLE
Update explorer.lua to use "find"

### DIFF
--- a/lua/snacks/picker/source/explorer.lua
+++ b/lua/snacks/picker/source/explorer.lua
@@ -283,14 +283,19 @@ end
 ---@type snacks.picker.finder
 function M.search(opts, ctx)
   opts = Snacks.picker.util.shallow_copy(opts)
-  opts.cmd = "rg"
+  opts.cmd = "find"
   opts.cwd = ctx.filter.cwd
   opts.notify = false
   opts.args = {
-    "--files",
-    "--hidden", -- include directories
-    "--glob",
-    "!git",
+    ".",
+    "-type", "f", -- include directories
+    "-name", ".*",
+    "-o",
+    "-name",
+    "*",
+    "-not",
+    "-path",
+    "*/.git/*",
     opts.path or ".",
   }
   opts.dirs = { ctx.filter.cwd }


### PR DESCRIPTION
Changed file to use find instead of ripgrep to search thourgh explorer.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

